### PR TITLE
refactor: merge query parameters

### DIFF
--- a/src/app/company/components/masterPage/masterpage.component.ts
+++ b/src/app/company/components/masterPage/masterpage.component.ts
@@ -221,6 +221,7 @@ export class MasterPageComponent implements OnChanges, OnInit {
     if (nav === false) return console.error("navigation error");
     return this.router.navigate(navUrlArray, {
       queryParams: pathQueryObject,
+      queryParamsHandling: "merge"
     });
   }
 


### PR DESCRIPTION
Looks like the parameters should be merged in order to preserve the state of the parent component? Great idea overall.